### PR TITLE
Notifications & path de-dupe

### DIFF
--- a/ArchiveHunterDownloadManager.xcodeproj/project.pbxproj
+++ b/ArchiveHunterDownloadManager.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		9BCA366022300B41004799F4 /* PreferencesController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA365F22300B41004799F4 /* PreferencesController.m */; };
 		9BCA366B22312F6F004799F4 /* ServerComms.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA366A22312F6F004799F4 /* ServerComms.m */; };
 		9BE8592C223696E2001D586A /* BulkDownloadStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE8592B223696E2001D586A /* BulkDownloadStats.m */; };
+		9BE859312236C5AC001D586A /* BulkOperationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE859302236C5AC001D586A /* BulkOperationsTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -78,6 +79,7 @@
 		9BCA366A22312F6F004799F4 /* ServerComms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ServerComms.m; sourceTree = "<group>"; };
 		9BE8592A223696E2001D586A /* BulkDownloadStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BulkDownloadStats.h; sourceTree = "<group>"; };
 		9BE8592B223696E2001D586A /* BulkDownloadStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BulkDownloadStats.m; sourceTree = "<group>"; };
+		9BE859302236C5AC001D586A /* BulkOperationsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BulkOperationsTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +167,7 @@
 			children = (
 				9BA935D1222E8C700066812F /* ArchiveHunterDownloadManagerTests.m */,
 				9BA935D3222E8C700066812F /* Info.plist */,
+				9BE859302236C5AC001D586A /* BulkOperationsTests.m */,
 			);
 			path = ArchiveHunterDownloadManagerTests;
 			sourceTree = "<group>";
@@ -367,6 +370,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9BA935D2222E8C700066812F /* ArchiveHunterDownloadManagerTests.m in Sources */,
+				9BE859312236C5AC001D586A /* BulkOperationsTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ArchiveHunterDownloadManager.xcodeproj/project.pbxproj
+++ b/ArchiveHunterDownloadManager.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		9BA935DD222E8C700066812F /* ArchiveHunterDownloadManagerUITests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BA935DC222E8C700066812F /* ArchiveHunterDownloadManagerUITests.m */; };
 		9BCA366022300B41004799F4 /* PreferencesController.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA365F22300B41004799F4 /* PreferencesController.m */; };
 		9BCA366B22312F6F004799F4 /* ServerComms.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BCA366A22312F6F004799F4 /* ServerComms.m */; };
+		9BE0C5D622370876000B0277 /* NotificationsHelper.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE0C5D522370876000B0277 /* NotificationsHelper.m */; };
 		9BE8592C223696E2001D586A /* BulkDownloadStats.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE8592B223696E2001D586A /* BulkDownloadStats.m */; };
 		9BE859312236C5AC001D586A /* BulkOperationsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 9BE859302236C5AC001D586A /* BulkOperationsTests.m */; };
 /* End PBXBuildFile section */
@@ -77,6 +78,8 @@
 		9BCA365F22300B41004799F4 /* PreferencesController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PreferencesController.m; sourceTree = "<group>"; };
 		9BCA366922312F6F004799F4 /* ServerComms.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ServerComms.h; sourceTree = "<group>"; };
 		9BCA366A22312F6F004799F4 /* ServerComms.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ServerComms.m; sourceTree = "<group>"; };
+		9BE0C5D422370876000B0277 /* NotificationsHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationsHelper.h; sourceTree = "<group>"; };
+		9BE0C5D522370876000B0277 /* NotificationsHelper.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NotificationsHelper.m; sourceTree = "<group>"; };
 		9BE8592A223696E2001D586A /* BulkDownloadStats.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BulkDownloadStats.h; sourceTree = "<group>"; };
 		9BE8592B223696E2001D586A /* BulkDownloadStats.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BulkDownloadStats.m; sourceTree = "<group>"; };
 		9BE859302236C5AC001D586A /* BulkOperationsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BulkOperationsTests.m; sourceTree = "<group>"; };
@@ -216,6 +219,8 @@
 				9B1044C72233022C001E637B /* DownloadDelegate.m */,
 				9BE8592A223696E2001D586A /* BulkDownloadStats.h */,
 				9BE8592B223696E2001D586A /* BulkDownloadStats.m */,
+				9BE0C5D422370876000B0277 /* NotificationsHelper.h */,
+				9BE0C5D522370876000B0277 /* NotificationsHelper.m */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -355,6 +360,7 @@
 				9BA935C2222E8C700066812F /* ArchiveHunterDownloadManager.xcdatamodeld in Sources */,
 				9BE8592C223696E2001D586A /* BulkDownloadStats.m in Sources */,
 				9B1044C82233022C001E637B /* DownloadDelegate.m in Sources */,
+				9BE0C5D622370876000B0277 /* NotificationsHelper.m in Sources */,
 				9BCA366B22312F6F004799F4 /* ServerComms.m in Sources */,
 				9BA935BF222E8C700066812F /* ViewController.m in Sources */,
 				9B1044BF223296C9001E637B /* BulkOperations.m in Sources */,

--- a/ArchiveHunterDownloadManager/AppDelegate.m
+++ b/ArchiveHunterDownloadManager/AppDelegate.m
@@ -30,6 +30,7 @@
 
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification {
     // Insert code here to initialize your application
+     [[NSUserNotificationCenter defaultUserNotificationCenter] setDelegate:self];
 }
 
 - (void)applictionWillTerminate:(NSNotification *)aNotification {
@@ -39,6 +40,17 @@
 - (void)registerMyApp {
     [[NSAppleEventManager sharedAppleEventManager] setEventHandler:self andSelector:@selector(getUrl:withReplyEvent:) forEventClass:kInternetEventClass andEventID:kAEGetURL];
 }
+
+
+/**
+ensure that the Notification Center pops-up our notifications
+ */
+- (BOOL)userNotificationCenter:(NSUserNotificationCenter *)center
+     shouldPresentNotification:(NSUserNotification *)notification
+{
+    return YES;
+}
+
 
 /**
  create a new data entry based on the info from the server

--- a/ArchiveHunterDownloadManager/Base.lproj/Main.storyboard
+++ b/ArchiveHunterDownloadManager/Base.lproj/Main.storyboard
@@ -794,8 +794,8 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
-                            <button verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9bA-3N-mTy">
-                                <rect key="frame" x="5" y="253" width="21" height="21"/>
+                            <button toolTip="Set download path" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9bA-3N-mTy">
+                                <rect key="frame" x="34" y="252" width="21" height="21"/>
                                 <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSActionTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="AwS-fY-Qjh">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -804,7 +804,7 @@
                                     <action selector="editClicked:" target="XfG-lQ-9wD" id="aCg-Yi-40f"/>
                                 </connections>
                             </button>
-                            <button verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="srv-x1-N3e">
+                            <button toolTip="Start downloading everything" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="srv-x1-N3e">
                                 <rect key="frame" x="722" y="253" width="24" height="21"/>
                                 <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRefreshTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JgW-LH-Srl">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -812,16 +812,6 @@
                                 </buttonCell>
                                 <connections>
                                     <action selector="runClicked:" target="XfG-lQ-9wD" id="CJW-69-TVP"/>
-                                </connections>
-                            </button>
-                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sp7-FW-6xu">
-                                <rect key="frame" x="34" y="253" width="23" height="21"/>
-                                <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSFolder" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Hry-oZ-wdK">
-                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                    <font key="font" metaFont="system"/>
-                                </buttonCell>
-                                <connections>
-                                    <action selector="revealClicked:" target="XfG-lQ-9wD" id="f9b-zC-jLe"/>
                                 </connections>
                             </button>
                             <scrollView ambiguous="YES" misplaced="YES" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="dQ6-7F-4VD">
@@ -944,29 +934,47 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
-                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eR9-eG-Y5O">
-                                <rect key="frame" x="299" y="245" width="96" height="32"/>
-                                <buttonCell key="cell" type="push" title="Click me!" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2NR-K5-N1D">
+                            <button toolTip="Remove bulk" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aaB-ed-uGp">
+                                <rect key="frame" x="5" y="252" width="21" height="21"/>
+                                <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Wqw-pn-EdS">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
                                 <connections>
-                                    <action selector="testMessageClicked:" target="XfG-lQ-9wD" id="Rab-CE-IPm"/>
+                                    <action selector="removeBulkClicked:" target="XfG-lQ-9wD" id="VMS-bK-DmZ"/>
+                                </connections>
+                            </button>
+                            <button toolTip="Reveal in Finder" verticalHuggingPriority="750" ambiguous="YES" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sp7-FW-6xu">
+                                <rect key="frame" x="63" y="252" width="23" height="21"/>
+                                <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSFolder" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Hry-oZ-wdK">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="revealClicked:" target="XfG-lQ-9wD" id="f9b-zC-jLe"/>
                                 </connections>
                             </button>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="Sp7-FW-6xu" firstAttribute="leading" secondItem="9bA-3N-mTy" secondAttribute="trailing" constant="8" id="1Ad-QI-9u6"/>
                             <constraint firstItem="RO2-xp-HhW" firstAttribute="top" secondItem="srv-x1-N3e" secondAttribute="bottom" constant="20" id="1cC-mn-j5h"/>
                             <constraint firstItem="srv-x1-N3e" firstAttribute="top" secondItem="dQ6-7F-4VD" secondAttribute="bottom" constant="8" id="4ju-2k-iPG"/>
-                            <constraint firstItem="9bA-3N-mTy" firstAttribute="top" secondItem="dQ6-7F-4VD" secondAttribute="bottom" constant="8" id="5so-g0-o2j"/>
+                            <constraint firstItem="RO2-xp-HhW" firstAttribute="top" secondItem="Sp7-FW-6xu" secondAttribute="bottom" constant="19" id="93V-rr-V5X"/>
                             <constraint firstAttribute="bottom" secondItem="RO2-xp-HhW" secondAttribute="bottom" constant="10" id="EoA-j0-JLy"/>
+                            <constraint firstItem="aaB-ed-uGp" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="5" id="GC7-sp-TPN"/>
+                            <constraint firstItem="9bA-3N-mTy" firstAttribute="top" secondItem="dQ6-7F-4VD" secondAttribute="bottom" constant="9" id="GuW-H4-bcI"/>
+                            <constraint firstItem="Sp7-FW-6xu" firstAttribute="leading" secondItem="9bA-3N-mTy" secondAttribute="trailing" constant="8" id="I1p-9d-VZN"/>
                             <constraint firstAttribute="trailing" secondItem="RO2-xp-HhW" secondAttribute="trailing" constant="15" id="IOd-Xq-387"/>
+                            <constraint firstItem="Sp7-FW-6xu" firstAttribute="top" secondItem="dQ6-7F-4VD" secondAttribute="bottom" constant="9" id="Ibr-gv-DWA"/>
+                            <constraint firstItem="RO2-xp-HhW" firstAttribute="top" secondItem="aaB-ed-uGp" secondAttribute="bottom" constant="19" id="OWz-OW-qsY"/>
+                            <constraint firstItem="9bA-3N-mTy" firstAttribute="leading" secondItem="aaB-ed-uGp" secondAttribute="trailing" constant="8" id="WsK-aA-qNQ"/>
                             <constraint firstAttribute="trailing" secondItem="srv-x1-N3e" secondAttribute="trailing" constant="20" id="b28-UL-NkY"/>
-                            <constraint firstItem="9bA-3N-mTy" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="5" id="b3h-lA-3aB"/>
+                            <constraint firstItem="RO2-xp-HhW" firstAttribute="top" secondItem="9bA-3N-mTy" secondAttribute="bottom" constant="19" id="gBu-F0-o4T"/>
                             <constraint firstItem="RO2-xp-HhW" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="5" id="gTu-r5-lpc"/>
                             <constraint firstItem="dQ6-7F-4VD" firstAttribute="top" secondItem="m2S-Jp-Qdl" secondAttribute="top" constant="9" id="iRB-Bx-r8d"/>
                             <constraint firstAttribute="trailing" secondItem="dQ6-7F-4VD" secondAttribute="trailing" constant="20" id="jxS-Md-Kvh"/>
-                            <constraint firstItem="RO2-xp-HhW" firstAttribute="top" secondItem="9bA-3N-mTy" secondAttribute="bottom" constant="24" id="srf-kT-PNR"/>
+                            <constraint firstItem="aaB-ed-uGp" firstAttribute="top" secondItem="dQ6-7F-4VD" secondAttribute="bottom" constant="9" id="kGI-ys-MNy"/>
+                            <constraint firstItem="9bA-3N-mTy" firstAttribute="leading" secondItem="aaB-ed-uGp" secondAttribute="trailing" constant="8" id="mBA-sq-QCW"/>
                             <constraint firstItem="dQ6-7F-4VD" firstAttribute="leading" secondItem="m2S-Jp-Qdl" secondAttribute="leading" constant="5" id="xhS-S3-9Jy"/>
                         </constraints>
                     </view>
@@ -1103,5 +1111,6 @@
         <image name="NSActionTemplate" width="14" height="14"/>
         <image name="NSFolder" width="32" height="32"/>
         <image name="NSRefreshTemplate" width="11" height="15"/>
+        <image name="NSRemoveTemplate" width="11" height="11"/>
     </resources>
 </document>

--- a/ArchiveHunterDownloadManager/Base.lproj/Main.storyboard
+++ b/ArchiveHunterDownloadManager/Base.lproj/Main.storyboard
@@ -944,6 +944,16 @@
                                     <autoresizingMask key="autoresizingMask"/>
                                 </tableHeaderView>
                             </scrollView>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eR9-eG-Y5O">
+                                <rect key="frame" x="299" y="245" width="96" height="32"/>
+                                <buttonCell key="cell" type="push" title="Click me!" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="2NR-K5-N1D">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="testMessageClicked:" target="XfG-lQ-9wD" id="Rab-CE-IPm"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <constraints>
                             <constraint firstItem="RO2-xp-HhW" firstAttribute="top" secondItem="srv-x1-N3e" secondAttribute="bottom" constant="20" id="1cC-mn-j5h"/>

--- a/ArchiveHunterDownloadManager/Base.lproj/Main.storyboard
+++ b/ArchiveHunterDownloadManager/Base.lproj/Main.storyboard
@@ -781,7 +781,7 @@
                                     </subviews>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="OeP-jy-yIN">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="OeP-jy-yIN">
                                     <rect key="frame" x="1" y="198" width="739" height="15"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>

--- a/ArchiveHunterDownloadManager/BulkOperations.h
+++ b/ArchiveHunterDownloadManager/BulkOperations.h
@@ -31,4 +31,7 @@ typedef enum BulkOperationStatus {
 - (BOOL) prepareBulkEntries:(NSManagedObject *)bulk withError:(NSError **)err;
 - (void) setupDownloadEntry:(NSManagedObject *)entry withBulk:(NSManagedObject *)bulk;
 
+
+- (NSString *)stripCommonPathComponents:(NSString *)bulkPath forEntryPath:(NSString *)entryPath;
+
 @end

--- a/ArchiveHunterDownloadManager/BulkOperations.m
+++ b/ArchiveHunterDownloadManager/BulkOperations.m
@@ -9,6 +9,7 @@
 
 #import "BulkOperations.h"
 #import "BulkDownloadStats.h"
+#import "NotificationsHelper.h"
 
 @implementation BulkOperations
 
@@ -255,14 +256,18 @@
         updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_RUNNING], @"status", nil];
     } else if([stats successCount]==[stats totalCount]){
         updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_COMPLETED], @"status", nil];
+        [NotificationsHelper showBulkCompletedNotification:bulk];
     } else if([stats successCount]+[stats invalidCount]==[stats totalCount]) {
         updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_COMPLETED], @"status", nil];
+        [NotificationsHelper showBulkCompletedNotification:bulk];
     } else if([stats waitingCount]>0){
         updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_WAITING_USER_INPUT], @"status", nil];
     } else if([stats errorCount]==[stats totalCount]){
         updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_ERRORED], @"status", nil];
+        [NotificationsHelper showBulkFailedNotification:bulk];
     } else if([stats errorCount]>0){
-        updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_ERRORED], @"partial", nil];
+        updates = [NSDictionary dictionaryWithObjectsAndKeys:[NSNumber numberWithInt:BO_PARTIAL], @"status", nil];
+        [NotificationsHelper showPartialFailedNotification:bulk];
     }
     
     [bulk setValuesForKeysWithDictionary:updates];

--- a/ArchiveHunterDownloadManager/BulkOperations.m
+++ b/ArchiveHunterDownloadManager/BulkOperations.m
@@ -172,10 +172,8 @@
                                  [self stripCommonPathComponents:[bulk valueForKey:@"destinationPath"] forEntryPath:[entry valueForKey:@"path"]
                                   ] stringByAppendingPathComponent:[entry valueForKey:@"name"]];
     
-    NSString *fileDestPath = [[bulk valueForKey:@"destinationPath"] stringByAppendingPathComponent:localDestString];
-    
     [entry setValuesForKeysWithDictionary:[NSDictionary dictionaryWithObjectsAndKeys:
-                                           fileDestPath, @"destinationFile",
+                                           localDestString, @"destinationFile",
                                            [NSNumber numberWithInteger:BO_READY], @"status",
                                            [NSNumber numberWithFloat:0.0], @"downloadProgress", nil]];
     

--- a/ArchiveHunterDownloadManager/NotificationsHelper.h
+++ b/ArchiveHunterDownloadManager/NotificationsHelper.h
@@ -1,0 +1,15 @@
+//
+//  NotificationsHelper.h
+//  ArchiveHunterDownloadManager
+//
+//  Created by Local Home on 11/03/2019.
+//  Copyright © 2019 Guardian News and Media. All rights reserved.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface NotificationsHelper : NSObject
++ (void)showBulkCompletedNotification:(NSManagedObject *)bulk;
++ (void)showBulkFailedNotification:(NSManagedObject *)bulk;
++ (void)showPartialFailedNotification:(NSManagedObject *)bulk;
+@end

--- a/ArchiveHunterDownloadManager/NotificationsHelper.m
+++ b/ArchiveHunterDownloadManager/NotificationsHelper.m
@@ -1,0 +1,78 @@
+//
+//  NotificationsHelper.m
+//  ArchiveHunterDownloadManager
+//
+//  Created by Local Home on 11/03/2019.
+//  Copyright © 2019 Guardian News and Media. All rights reserved.
+//
+
+#import "NotificationsHelper.h"
+
+@implementation NotificationsHelper
+
++ (void)showNotification:(NSString *)body withId:(NSString *_Nullable)identifier withTitle:(NSString *_Nonnull)title withImageNamed:(NSString *)imageName
+{
+    NSUserNotification *not = [[NSUserNotification alloc] init];
+    [not setInformativeText:body];
+    [not setTitle:title];
+    [not setIdentifier:identifier];
+    
+    NSUserNotificationCenter *cen = [NSUserNotificationCenter defaultUserNotificationCenter];
+    [cen deliverNotification:not];
+}
+
++ (NSString *)bestDescription:(NSManagedObject *)bulk
+{
+    NSError *matchErr;
+    NSRegularExpression *xtractor = [NSRegularExpression regularExpressionWithPattern:@"^([^:]*):(.*)$"
+                                                                             options:NSRegularExpressionCaseInsensitive
+                                                                               error:&matchErr];
+    
+    NSString *path = [bulk valueForKey:@"destinationPath"];
+    if(path && [path length]>0){
+        return [[path lastPathComponent] length]==0 ? path : [path lastPathComponent];
+    } else {
+        NSString *desc = [bulk valueForKey:@"downloadDescription"];
+        NSArray <NSTextCheckingResult *> *matches = [xtractor matchesInString:desc options:0 range:NSMakeRange(0, [desc length])];
+        if(!matches || [matches count]<2){
+            return desc;
+        } else {
+            NSString *srcPath = [desc substringWithRange:[[matches objectAtIndex:1] range]];
+            return [srcPath lastPathComponent];
+        }
+    }
+}
+
++ (void)showBulkCompletedNotification:(NSManagedObject *)bulk
+{
+    NSString *bodyText = [NotificationsHelper bestDescription:bulk];
+    NSString *idString = [NSString stringWithFormat:@"%lx", (void *)bulk];
+    
+    [NotificationsHelper showNotification:bodyText
+                                   withId:idString
+                                withTitle:@"Media download completed"
+                           withImageNamed:@"AppIcon"];
+}
+
++ (void)showBulkFailedNotification:(NSManagedObject *)bulk
+{
+    NSString *bodyText = [NotificationsHelper bestDescription:bulk];
+    NSString *idString = [NSString stringWithFormat:@"%lx", (void *)bulk];
+    
+    [NotificationsHelper showNotification:bodyText
+                                   withId:idString
+                                withTitle:@"Media download failed"
+                           withImageNamed:@"AppIcon"];
+}
+
++ (void)showPartialFailedNotification:(NSManagedObject *)bulk
+{
+    NSString *bodyText = [NotificationsHelper bestDescription:bulk];
+    NSString *idString = [NSString stringWithFormat:@"%lx", (void *)bulk];
+    
+    [NotificationsHelper showNotification:bodyText
+                                   withId:idString
+                                withTitle:@"Some items failed to download"
+                           withImageNamed:@"AppIcon"];
+}
+@end

--- a/ArchiveHunterDownloadManager/ViewController.m
+++ b/ArchiveHunterDownloadManager/ViewController.m
@@ -48,39 +48,40 @@
     // Update the view, if already loaded.
 }
 
-- (IBAction)testClicked:(id)sender {
-    NSError *err;
-    NSManagedObjectContext *ctx = [[self appDelegate] managedObjectContext];
-    
-    NSManagedObject* ent=[NSEntityDescription insertNewObjectForEntityForName:@"DownloadEntity" inManagedObjectContext:ctx];
-    [ent setValuesForKeysWithDictionary:
-     [NSDictionary dictionaryWithObjectsAndKeys:
-      @"test1",@"name",
-      [NSNumber numberWithDouble:0.5], @"downloadProgress",
-      @"Normal", @"priority",
-      nil]
-     ];
-    [ctx save:&err];
-    if(err){
-        NSLog(@"Could not save: %@", err);
-    }
-}
-
-- (IBAction)editClicked:(id)sender {
+/**
+ gets the NSManagedObject pointer for the currently selected bulk.
+ displays an alert panel with 'failureMessage' if nothing is selected
+ otherwise calls the provided block passing the NSManagedObject pointer as the argument
+ */
+- (void)withSelectedBulk:(NSString *)failureMessage block:(void(^)(NSManagedObject *))block
+{
     NSWindow *window = [[self view] window];
     NSArray *selection = [_bulkArrayController selectedObjects];
     if([selection count]==0){
         NSAlert *alrt = [[NSAlert alloc] init];
-        [alrt setInformativeText:@"You must select a bulk entry to edit"];
+        [alrt setInformativeText:failureMessage];
         [alrt beginSheetModalForWindow:window completionHandler:^(NSInteger result){
             
         }];
     } else {
         NSManagedObject *selectedBulk = [selection objectAtIndex:0];
-        [self askUserForPath:selectedBulk];
+        
+        block(selectedBulk);
     }
 }
 
+/**
+ user has clicked the "cog" button, show the edit box
+ */
+- (IBAction)editClicked:(id)sender {
+    [self withSelectedBulk:@"You must select a bulk entry to edit" block:^(NSManagedObject *selectedBulk){
+        [self askUserForPath:selectedBulk];
+    }];
+}
+
+/**
+ user has clicked the "reload" button, start off downloads
+ */
 - (IBAction)runClicked:(id)sender {
     NSWindow *window = [[self view] window];
     NSError *err;
@@ -96,18 +97,12 @@
     
 }
 
+/**
+ user has clicked the "folder" button, reveal the download location in Finder
+ */
 - (IBAction)revealClicked:(id)sender {
     NSWindow *window = [[self view] window];
-    NSArray *selection = [_bulkArrayController selectedObjects];
-    if([selection count]==0){
-        NSAlert *alrt = [[NSAlert alloc] init];
-        [alrt setInformativeText:@"You must select a bulk entry to reveal"];
-        [alrt beginSheetModalForWindow:window completionHandler:^(NSInteger result){
-            
-        }];
-    } else {
-        NSManagedObject *selectedBulk = [selection objectAtIndex:0];
-        
+    [self withSelectedBulk:@"You must select a bulk entry to reveal" block:^(NSManagedObject *selectedBulk){
         NSString *bulkDir = [selectedBulk valueForKey:@"destinationPath"];
         if(bulkDir){
             [[NSWorkspace sharedWorkspace] openFile:bulkDir];
@@ -118,7 +113,40 @@
                 
             }];
         }
-    }
+    }];
+}
+
+/**
+ user has clicked the "minus" button, remove the bulk and its contents from the memory store
+ */
+- (IBAction)removeBulkClicked:(id)sender
+{
+    NSWindow *window = [[self view] window];
+    [self withSelectedBulk:@"You must select a bulk entry to remove" block:^(NSManagedObject *selectedBulk){
+        NSError *iterationError=nil, *saveError=nil;
+        NSManagedObjectContext *moc = [[self appDelegate] managedObjectContext];
+        BulkOperationStatus status = [(NSNumber *)[selectedBulk valueForKey:@"status"] intValue];
+        if(status==BO_RUNNING){
+            [self showErrorBox:@"You can't remove a download that is in progress"];
+        } else {
+            //first remove all of the downloads
+            [BulkOperations bulkForEach:selectedBulk managedObjectContext:moc withError:&iterationError block:^(NSManagedObject *entry){
+                [moc deleteObject:entry];
+            }];
+            
+            if(iterationError){
+                NSAlert *alrt = [NSAlert alertWithError:iterationError];
+                [alrt beginSheetModalForWindow:window completionHandler:nil];
+            } else {
+                [moc deleteObject:selectedBulk];
+                [moc save:&saveError];
+                if(saveError){
+                    NSAlert *alrt = [NSAlert alertWithError:iterationError];
+                    [alrt beginSheetModalForWindow:window completionHandler:nil];
+                }
+            }
+        }
+    }];
 }
 
 - (IBAction)testMessageClicked:(id)sender
@@ -137,6 +165,9 @@
     }
 }
 
+/**
+ pop up an Open dialog to ask the user where they want to save this bulk download
+ */
 - (void) askUserForPath:(NSManagedObject *)bulk {
     NSWindow *window = [[self view] window];
     NSOpenPanel *panel = [NSOpenPanel openPanel];
@@ -165,6 +196,9 @@
     }];
 }
 
+/**
+ simple helper method to show an error box as a window-modal sheet
+ */
 - (void) showErrorBox:(NSString *)msg {
     NSWindow *window = [[self view] window];
 

--- a/ArchiveHunterDownloadManager/ViewController.m
+++ b/ArchiveHunterDownloadManager/ViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "ViewController.h"
+#import "NotificationsHelper.h"
 
 @implementation ViewController
 @synthesize appDelegate;
@@ -119,6 +120,23 @@
         }
     }
 }
+
+- (IBAction)testMessageClicked:(id)sender
+{
+    NSWindow *window = [[self view] window];
+    NSArray *selection = [_bulkArrayController selectedObjects];
+    if([selection count]==0){
+        NSAlert *alrt = [[NSAlert alloc] init];
+        [alrt setInformativeText:@"You must select a bulk entry to reveal"];
+        [alrt beginSheetModalForWindow:window completionHandler:^(NSInteger result){
+            
+        }];
+    } else {
+        NSManagedObject *selectedBulk = [selection objectAtIndex:0];
+        [NotificationsHelper showPartialFailedNotification:selectedBulk];
+    }
+}
+
 - (void) askUserForPath:(NSManagedObject *)bulk {
     NSWindow *window = [[self view] window];
     NSOpenPanel *panel = [NSOpenPanel openPanel];

--- a/ArchiveHunterDownloadManager/ViewController.m
+++ b/ArchiveHunterDownloadManager/ViewController.m
@@ -24,8 +24,6 @@
                         change:(NSDictionary *)change
                        context:(void *)context
 {
-    NSLog(@"observeValueForKeyPath: %@", keyPath);
-    
     if([keyPath compare:@"selectionIndex"]==NSOrderedSame){
         [self setDownloadEntryFilterPredicate:[NSPredicate predicateWithBlock:^BOOL(id  _Nonnull evaluatedObject, NSDictionary<NSString *,id> * _Nullable bindings) {
             NSManagedObject *entry = (NSManagedObject *)evaluatedObject;
@@ -34,6 +32,7 @@
         }]];
     }
 }
+
 - (void)viewDidLoad {
     [super viewDidLoad];
 

--- a/ArchiveHunterDownloadManagerTests/ArchiveHunterDownloadManagerTests.m
+++ b/ArchiveHunterDownloadManagerTests/ArchiveHunterDownloadManagerTests.m
@@ -7,6 +7,7 @@
 //
 
 #import <XCTest/XCTest.h>
+#import "BulkOperations.h"
 
 @interface ArchiveHunterDownloadManagerTests : XCTestCase
 

--- a/ArchiveHunterDownloadManagerTests/BulkOperationsTests.m
+++ b/ArchiveHunterDownloadManagerTests/BulkOperationsTests.m
@@ -30,13 +30,21 @@
     
     NSString *result = [op stripCommonPathComponents:@"/path/to/my" forEntryPath:@"/path/to/my/download/directory"];
     NSLog(@"stripCommonPathComponents: %@",result);
-    XCTAssertEqual([result compare:@"download/directory"], NSOrderedSame);
+    XCTAssertEqual([result compare:@"/path/to/my/download/directory"], NSOrderedSame);
 }
 
 - (void)testStripCommonPathComponentsFromMiddle {
     BulkOperations *op = [[BulkOperations alloc] init];
     
     NSString *result = [op stripCommonPathComponents:@"/path/to/my/downloads" forEntryPath:@"downloads/projectname/media"];
+    NSLog(@"stripCommonPathComponents: %@",result);
+    XCTAssertEqual([result compare:@"/path/to/my/downloads/projectname/media"], NSOrderedSame);
+}
+
+- (void)testStripCommonPathComponentsCompletelyDifferent {
+    BulkOperations *op = [[BulkOperations alloc] init];
+    
+    NSString *result = [op stripCommonPathComponents:@"/path/to/my/downloads" forEntryPath:@"projectname/media"];
     NSLog(@"stripCommonPathComponents: %@",result);
     XCTAssertEqual([result compare:@"/path/to/my/downloads/projectname/media"], NSOrderedSame);
 }

--- a/ArchiveHunterDownloadManagerTests/BulkOperationsTests.m
+++ b/ArchiveHunterDownloadManagerTests/BulkOperationsTests.m
@@ -1,0 +1,43 @@
+//
+//  BulkOperationsTests.m
+//  ArchiveHunterDownloadManager
+//
+//  Created by Local Home on 11/03/2019.
+//  Copyright © 2019 Guardian News and Media. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "BulkOperations.h"
+
+@interface BulkOperationsTests : XCTestCase
+
+@end
+
+@implementation BulkOperationsTests
+
+- (void)setUp {
+    [super setUp];
+    // Put setup code here. This method is called before the invocation of each test method in the class.
+}
+
+- (void)tearDown {
+    // Put teardown code here. This method is called after the invocation of each test method in the class.
+    [super tearDown];
+}
+
+- (void)testStripCommonPathComponentsFromRoot {
+    BulkOperations *op = [[BulkOperations alloc] init];
+    
+    NSString *result = [op stripCommonPathComponents:@"/path/to/my" forEntryPath:@"/path/to/my/download/directory"];
+    NSLog(@"stripCommonPathComponents: %@",result);
+    XCTAssertEqual([result compare:@"download/directory"], NSOrderedSame);
+}
+
+- (void)testStripCommonPathComponentsFromMiddle {
+    BulkOperations *op = [[BulkOperations alloc] init];
+    
+    NSString *result = [op stripCommonPathComponents:@"/path/to/my/downloads" forEntryPath:@"downloads/projectname/media"];
+    NSLog(@"stripCommonPathComponents: %@",result);
+    XCTAssertEqual([result compare:@"/path/to/my/downloads/projectname/media"], NSOrderedSame);
+}
+@end


### PR DESCRIPTION
This is a rollup of two seperate pieces of work:

1. If the user requests a download to a path which overlaps with the source media's path (e.g., media path is `myproject/footage/cam1.mxf` and selected download path is `/path/to/myproject`, then the resulting file will be placed in `/path/to/myproject/footage/cam1.mxf` as opposed to `/path/to/myproject/myproject/footage/cam1.mxf` which is what would happen with simple concatenation
2. Adding on-screen popup notifications when bulk downloads succeed or fail