### PR TITLE
Show the User an Alert if a Network Error Happens when Attempting to Access the Server

### DIFF
--- a/ArchiveHunterDownloadManager/ServerComms.m
+++ b/ArchiveHunterDownloadManager/ServerComms.m
@@ -41,6 +41,11 @@
         
          if(error){
              completionBlock(nil, error);
+             NSAlert *alert = [[NSAlert alloc] init];
+             [alert setMessageText:@"Network Error"];
+             [alert setInformativeText:@"A network error occured. Please check if the server domain name is set connectly in the Preferences window."];
+             [alert addButtonWithTitle:@"Okay"];
+             [alert runModal];
          } else {
              
             NSDictionary *json = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:&parseError];


### PR DESCRIPTION
An alert window is now displayed if a network error happens when an attempt is made to access the server.

![image](https://user-images.githubusercontent.com/10620802/54294200-1ecc3600-45a9-11e9-834c-6a869e002b6b.png)

Tested on a machine running macOS 10.11.6.

@fredex42