### PR TITLE
Error Messages and Hide Completed Button

### DIFF
--- a/ArchiveHunterDownloadManager/AppDelegate.m
+++ b/ArchiveHunterDownloadManager/AppDelegate.m
@@ -141,6 +141,13 @@ ensure that the Notification Center pops-up our notifications
             
             if(err){
                 NSLog(@"Download error: %@", err);
+                
+                NSString *errorString = [NSString stringWithFormat:@"%@", err];
+                NSAlert *alert = [[NSAlert alloc] init];
+                [alert setMessageText:@"Download Error"];
+                [alert setInformativeText:[NSString stringWithFormat:@"A download error occured: %@", [errorString substringToIndex:256]]];
+                [alert addButtonWithTitle:@"Okay"];
+                [alert runModal];
             } else {
                 //NSLog(@"Got data: %@", data);
                 NSDictionary *metadata = [data objectForKey:@"metadata"];
@@ -210,6 +217,13 @@ ensure that the Notification Center pops-up our notifications
             NSLog(@"bulk is %@", bulk);
             if(![[self managedObjectContext] save:&err]){
                 NSLog(@"Could not save managed objects: %@", err);
+                
+                NSString *errorString = [NSString stringWithFormat:@"%@", err];
+                NSAlert *alert = [[NSAlert alloc] init];
+                [alert setMessageText:@"Save Error"];
+                [alert setInformativeText:[NSString stringWithFormat:@"A saving error occured: %@", [errorString substringToIndex:256]]];
+                [alert addButtonWithTitle:@"Okay"];
+                [alert runModal];
             }
         }
     });

--- a/ArchiveHunterDownloadManager/DownloadDelegate.m
+++ b/ArchiveHunterDownloadManager/DownloadDelegate.m
@@ -68,6 +68,13 @@
 - (void)download:(NSURLDownload *)download didFailWithError:(NSError *)error
 {
     NSLog(@"Download %@ failed with error %@", [[self entry] valueForKey:@"destinationFile"], error);
+
+    NSString *errorString = [NSString stringWithFormat:@"%@", error];
+    NSAlert *alert = [[NSAlert alloc] init];
+    [alert setMessageText:@"File Download Error"];
+    [alert setInformativeText:[NSString stringWithFormat:@"A file download error occured: %@", [errorString substringToIndex:256]]];
+    [alert addButtonWithTitle:@"Okay"];
+    [alert runModal];
     
     [[self entry] setValuesForKeysWithDictionary:[NSDictionary dictionaryWithObjectsAndKeys:
                                                   [error localizedDescription],@"lastError",

--- a/ArchiveHunterDownloadManager/ViewController.h
+++ b/ArchiveHunterDownloadManager/ViewController.h
@@ -19,6 +19,7 @@
 
 @property (strong, atomic) NSPredicate* downloadEntryFilterPredicate;
 @property (strong, atomic) NSIndexSet *bulkSelectionIndices;
+@property (strong, atomic) NSNumber* hideCompleted;
 
 - (void) askUserForPath:(NSManagedObject *)bulk;
 - (void) showErrorBox:(NSString *)msg;


### PR DESCRIPTION
Adds three new alert windows for error messages and a hide completed toggle check box which causes completed file downloads to disappear and come back again.

Tested on a machine running macOS 10.11.6.

@fredex42 