### PR TITLE
Add versioning to coredata bundle

### DIFF
--- a/ArchiveHunterDownloadManager/AppDelegate.m
+++ b/ArchiveHunterDownloadManager/AppDelegate.m
@@ -312,7 +312,12 @@ ensure that the Notification Center pops-up our notifications
     
     if (!shouldFail && !error) {
         NSPersistentStoreCoordinator *coordinator = [[NSPersistentStoreCoordinator alloc] initWithManagedObjectModel:[self managedObjectModel]];
-        NSURL *url = [applicationDocumentsDirectory URLByAppendingPathComponent:@"OSXCoreDataObjC.storedata"];
+        NSNumber *versionNo = [[[NSBundle mainBundle] infoDictionary] valueForKey:@"CFBundleShortVersionString"];
+        
+        NSString *dataStoreFilename = [NSString stringWithFormat:@"coredata-%@.storedata", versionNo];
+        NSURL *url = [applicationDocumentsDirectory URLByAppendingPathComponent:dataStoreFilename];
+        NSLog(@"Loading persistent data from %@", url);
+        
         if (![coordinator addPersistentStoreWithType:NSXMLStoreType configuration:nil URL:url options:nil error:&error]) {
             coordinator = nil;
         }

--- a/ci_scripts/set_build_info.sh
+++ b/ci_scripts/set_build_info.sh
@@ -15,4 +15,4 @@ else
 fi
 
 /usr/libexec/PlistBuddy -c "Set :CFBundleVersion Build ${BUILD_NUMBER}${BRANCH_SUFFIX}" "ArchiveHunterDownloadManager/Info.plist"
-
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${BUILD_NUMBER}" "ArchiveHunterDownloadManager/Info.plist"


### PR DESCRIPTION
Changes core data file name to include the bundle version to prevent crashes due to incompatible data stores

https://trello.com/c/HYYyUYmT