### PR TITLE
Write Files which are Meant to have Zero Size to Storage

### DIFF
--- a/ArchiveHunterDownloadManager/BulkOperations.m
+++ b/ArchiveHunterDownloadManager/BulkOperations.m
@@ -218,12 +218,8 @@
     
     BOOL result = [BulkOperations bulkForEach:bulk managedObjectContext:_moc withError:err block:^(NSManagedObject *entry){
         dispatch_async(targetQueue, ^{
-            if([[entry valueForKey:@"fileSize"] longLongValue]>0){
-                NSLog(@"adding entry to queue manager");
-                [[self qManager] addToQueue:entry];
-            } else {
-                [entry setValue:[NSNumber numberWithInt:BO_INVALID] forKey:@"status"];
-            }
+            NSLog(@"adding entry to queue manager");
+            [[self qManager] addToQueue:entry];
         });
     }];
     

--- a/ArchiveHunterDownloadManager/CurlDownloader.m
+++ b/ArchiveHunterDownloadManager/CurlDownloader.m
@@ -245,7 +245,7 @@ int early_abort_progresscb(void *clientp,   double dltotal,   double dlnow,   do
     _currentFile = [[MMappedFile alloc] initWithFile:filePath];
     //O_EXCL means "fail if creating and the file already exists"
     result = [_currentFile open:O_CREAT|O_EXCL|O_EXLOCK|O_RDWR withSize:[[_headInfo size] longLongValue] withError:err];
-    if(!result) {
+    if((!result) && ([[_headInfo size] longLongValue] != 0)) {
         NSLog(@"file open failed: %@", [*err localizedDescription]);
         return false;
     }


### PR DESCRIPTION
## What does this change?

Files with zero size are now passed to the download queue so they are later written to storage. An error in the downloader should not happen if the file really is meant to have zero size.

## How to test

Build the software. Put a file with zero size in an S3 bucket. Attempt to download it. It should now get written to storage.

## How can we measure success?

Files that are meant to have zero size get written to storage.
